### PR TITLE
Fix issue #52 from the Azure repo ReadableStreamDefaultReadResult

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -21,7 +21,7 @@ export interface EventSourceMessage {
  */
 export async function getBytes(stream: ReadableStream<Uint8Array>, onChunk: (arr: Uint8Array) => void) {
     const reader = stream.getReader();
-    let result: ReadableStreamDefaultReadResult<Uint8Array>;
+    let result: ReadableStreamReadResult<Uint8Array>;
     while (!(result = await reader.read()).done) {
         onChunk(result.value);
     }


### PR DESCRIPTION
Fix issue [Cannot find name 'ReadableStreamDefaultReadResult' #52](https://github.com/Azure/fetch-event-source/issues/52)

> ```ts
> let result: ReadableStreamDefaultReadResult<Uint8Array>;
> ```
> 
> https://github.com/Azure/fetch-event-source/blob/1589ec1f49d96450f3bae9adb20ab4a5b3deb204/src/parse.ts#L24C61-L24C61
> 
> ```
> > @microsoft/fetch-event-source@2.0.1 build
> > tsc && tsc -p tsconfig.esm.json
> 
> src/parse.ts:24:17 - error TS2552: Cannot find name 'ReadableStreamDefaultReadResult'. Did you mean 'ReadableStreamDefaultReader'?
> 
> 24     let result: ReadableStreamDefaultReadResult<Uint8Array>;
>                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> 
>   node_modules/typescript/lib/lib.dom.d.ts:11665:13
>     11665 declare var ReadableStreamDefaultReader: {
>                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     'ReadableStreamDefaultReader' is declared here.
> 
> 
> Found 1 error in src/parse.ts:24
> ```

